### PR TITLE
ZippedResourcePack: Handle json decoding errors correctly

### DIFF
--- a/src/pocketmine/resourcepacks/ZippedResourcePack.php
+++ b/src/pocketmine/resourcepacks/ZippedResourcePack.php
@@ -86,7 +86,7 @@ class ZippedResourcePack implements ResourcePack{
 		$archive->close();
 
 		$manifest = json_decode($manifestData);
-		if(!self::verifyManifest($manifest)){
+		if($manifest === null or !self::verifyManifest($manifest)){
 			throw new \InvalidStateException("Could not load resource pack from $zipPath: manifest.json is invalid or incomplete");
 		}
 


### PR DESCRIPTION
Previously this would crash if it failed to decode the JSON (https://forums.pmmp.io/threads/texture-pack-shows-errors-not-working.4880/)

## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
